### PR TITLE
Fixed URL in the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LolDriverScan
 
 LolDriverScan is a golang tool that allows users to discover vulnerable drivers on their system.
-This tool fetches the loldriverscan.io list from their APIs and scans the system for any vulnerable drivers
+This tool fetches the [loldrivers.io](https://www.loldrivers.io/) list from their APIs and scans the system for any vulnerable drivers
 This project is implemented in Go and does not require elevated privileges to run.
 
 ## Features


### PR DESCRIPTION
The URL in the description is `loldriverscan.io`. Since this is the first time hearing about this, I put the URL in my browser to come across a dead link.

Checking the source code, I assume this is the real URL you meant to put.